### PR TITLE
feat: add async evaluation and run artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,23 @@ print(report)
 bench.export_results(results, format="json", path="results.json")
 ```
 
+### Async Agents
+
+```python
+import asyncio
+
+from agentbench import AgentBench, BenchmarkTask
+
+bench = AgentBench(name="async-eval")
+bench.register_task(name="capital-lookup", expected="Paris")
+
+async def async_agent(task: BenchmarkTask) -> str:
+    await asyncio.sleep(0)
+    return "Paris"
+
+results = asyncio.run(bench.run_evaluation_async(async_agent))
+```
+
 ### Comparing Multiple Agents
 
 ```python
@@ -118,6 +135,19 @@ comparison = bench.compare_agents(
 print(comparison)
 ```
 
+### Run Artifacts And Leaderboard Entries
+
+```python
+results = bench.run_evaluation(agent_fn=my_agent, tasks=bench.tasks)
+artifact = bench.export_run_artifact(results, path="artifacts")
+print(artifact.run_id)
+```
+
+That export writes:
+
+- one JSON bundle containing tasks, raw results, and summary metrics
+- one `leaderboard.jsonl` append-only file for lightweight cross-run comparison
+
 ## Features
 
 - **Task Registration** — define benchmark tasks with expected outputs and custom evaluators
@@ -127,6 +157,8 @@ print(comparison)
 - **Agent Comparison** — side-by-side evaluation of multiple agents on the same task suite
 - **Report Generation** — human-readable Markdown reports with summary statistics
 - **Flexible Export** — output results as JSON, CSV, or Markdown
+- **Async Support** — benchmark async agent callables without sync wrappers
+- **Run Artifacts** — persist benchmark bundles and leaderboard-ready summaries
 
 ## Who This Is For
 

--- a/src/agentbench/__init__.py
+++ b/src/agentbench/__init__.py
@@ -1,6 +1,6 @@
 """AgentBench — AI agent evaluation and benchmarking suite."""
 
-from agentbench.core import AgentBench, BenchmarkTask, EvalResult
+from agentbench.core import AgentBench, BenchmarkTask, EvalResult, RunArtifact
 from agentbench.config import BenchConfig
 from agentbench.utils import (
     calculate_accuracy,
@@ -14,6 +14,7 @@ __all__ = [
     "AgentBench",
     "BenchmarkTask",
     "EvalResult",
+    "RunArtifact",
     "BenchConfig",
     "calculate_accuracy",
     "calculate_efficiency_score",

--- a/src/agentbench/core.py
+++ b/src/agentbench/core.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
-import time
+import asyncio
+import inspect
+import json
 import logging
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Callable, Optional
 
 from pydantic import BaseModel, Field
@@ -66,6 +72,18 @@ class EvalResult(BaseModel):
         default_factory=dict,
         description="Additional metadata from the evaluation run",
     )
+
+
+class RunArtifact(BaseModel):
+    """Structured artifact bundle for one evaluation run."""
+
+    run_id: str
+    bench_name: str
+    created_at: str
+    tasks: list[dict[str, Any]]
+    results: list[dict[str, Any]]
+    summary: dict[str, Any]
+    leaderboard_entry: dict[str, Any]
 
 
 # ---------------------------------------------------------------------------
@@ -195,6 +213,54 @@ class AgentBench:
 
         return results
 
+    async def run_evaluation_async(
+        self,
+        agent_fn: Callable[[BenchmarkTask], Any],
+        tasks: list[BenchmarkTask] | None = None,
+    ) -> list[EvalResult]:
+        """Run sync or async *agent_fn* on each task and collect results."""
+        target_tasks = tasks if tasks is not None else self.tasks
+        results: list[EvalResult] = []
+
+        for task in target_tasks:
+            start = time.perf_counter()
+            error: str | None = None
+            actual: Any = None
+            steps = 1
+            tool_calls: list[str] = []
+
+            try:
+                raw = agent_fn(task)
+                if inspect.isawaitable(raw):
+                    raw = await raw
+                if isinstance(raw, dict):
+                    actual = raw.get("answer", raw)
+                    steps = raw.get("steps", 1)
+                    tool_calls = raw.get("tool_calls", [])
+                else:
+                    actual = raw
+            except Exception as exc:  # noqa: BLE001
+                error = str(exc)
+                logger.warning("Task '%s' raised: %s", task.name, error)
+
+            elapsed = time.perf_counter() - start
+            eval_fn = task.evaluator or default_evaluator
+            correct = False if error else eval_fn(actual, task.expected)
+
+            result = EvalResult(
+                task_name=task.name,
+                expected=task.expected,
+                actual=actual,
+                correct=correct,
+                steps=steps,
+                duration_seconds=round(elapsed, 6),
+                error=error,
+                tool_calls=tool_calls,
+            )
+            results.append(result)
+
+        return results
+
     # ------------------------------------------------------------------
     # Scoring
     # ------------------------------------------------------------------
@@ -246,6 +312,19 @@ class AgentBench:
 
         return format_comparison_table(all_results, self.config.max_steps)
 
+    async def compare_agents_async(
+        self,
+        agent_fns: dict[str, Callable[[BenchmarkTask], Any]],
+        tasks: list[BenchmarkTask] | None = None,
+    ) -> str:
+        """Evaluate multiple sync or async agents and return a comparison table."""
+        all_results: dict[str, list[EvalResult]] = {}
+        for agent_name, fn in agent_fns.items():
+            logger.info("Evaluating agent '%s' ...", agent_name)
+            all_results[agent_name] = await self.run_evaluation_async(fn, tasks)
+
+        return format_comparison_table(all_results, self.config.max_steps)
+
     # ------------------------------------------------------------------
     # Reporting & export
     # ------------------------------------------------------------------
@@ -290,6 +369,63 @@ class AgentBench:
 
         lines.append("")
         return "\n".join(lines)
+
+    def build_run_artifact(
+        self,
+        results: list[EvalResult],
+        tasks: list[BenchmarkTask] | None = None,
+    ) -> RunArtifact:
+        """Build a structured artifact bundle for one benchmark run."""
+        run_id = uuid.uuid4().hex[:12]
+        created_at = datetime.now(timezone.utc).isoformat()
+        target_tasks = tasks if tasks is not None else self.tasks
+        accuracy = self.score_accuracy(results)
+        efficiency = self.score_efficiency(results)
+        total_time = sum(r.duration_seconds for r in results)
+        summary = {
+            "task_count": len(results),
+            "accuracy": accuracy,
+            "efficiency": efficiency,
+            "total_duration_seconds": round(total_time, 6),
+            "error_count": sum(1 for r in results if r.error),
+        }
+        leaderboard_entry = {
+            "run_id": run_id,
+            "bench_name": self.config.name,
+            "accuracy": accuracy,
+            "efficiency": efficiency,
+            "task_count": len(results),
+            "created_at": created_at,
+        }
+        return RunArtifact(
+            run_id=run_id,
+            bench_name=self.config.name,
+            created_at=created_at,
+            tasks=[task.model_dump() for task in target_tasks],
+            results=results_to_dicts(results),
+            summary=summary,
+            leaderboard_entry=leaderboard_entry,
+        )
+
+    def export_run_artifact(
+        self,
+        results: list[EvalResult],
+        path: str,
+        tasks: list[BenchmarkTask] | None = None,
+    ) -> RunArtifact:
+        """Write a run artifact bundle and leaderboard summary to disk."""
+        artifact = self.build_run_artifact(results, tasks)
+        target_dir = Path(path)
+        target_dir.mkdir(parents=True, exist_ok=True)
+        bundle_path = target_dir / f"{artifact.run_id}.json"
+        leaderboard_path = target_dir / "leaderboard.jsonl"
+        bundle_path.write_text(
+            json.dumps(artifact.model_dump(), indent=2, default=str),
+            encoding="utf-8",
+        )
+        with leaderboard_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(artifact.leaderboard_entry) + "\n")
+        return artifact
 
     def export_results(
         self,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
+from pathlib import Path
 
 import pytest
 
@@ -75,6 +77,27 @@ class TestRunEvaluation:
         assert results[0].error == "kaboom"
         assert not results[0].correct
 
+    def test_async_agent_supported(self, bench: AgentBench) -> None:
+        async def async_agent(task: BenchmarkTask) -> str | int:
+            await asyncio.sleep(0)
+            return _perfect_agent(task)
+
+        results = asyncio.run(bench.run_evaluation_async(async_agent))
+        assert all(r.correct for r in results)
+
+    def test_async_agent_exception_captured(self) -> None:
+        b = AgentBench(name="async-err")
+        b.register_task(name="boom", expected="ok")
+
+        async def exploding_agent(task: BenchmarkTask) -> str:
+            await asyncio.sleep(0)
+            raise RuntimeError("async kaboom")
+
+        results = asyncio.run(b.run_evaluation_async(exploding_agent))
+        assert len(results) == 1
+        assert results[0].error == "async kaboom"
+        assert not results[0].correct
+
 
 class TestScoring:
     def test_accuracy_perfect(self, bench: AgentBench) -> None:
@@ -127,3 +150,39 @@ class TestCompareAgents:
         assert "Bad" in table
         assert "100.00%" in table
         assert "0.00%" in table
+
+    def test_async_comparison_table(self, bench: AgentBench) -> None:
+        async def async_agent(task: BenchmarkTask) -> str | int:
+            await asyncio.sleep(0)
+            return _perfect_agent(task)
+
+        table = asyncio.run(
+            bench.compare_agents_async({"Async Perfect": async_agent, "Bad": _bad_agent})
+        )
+        assert "Async Perfect" in table
+        assert "Bad" in table
+
+
+class TestArtifacts:
+    def test_build_run_artifact(self, bench: AgentBench) -> None:
+        results = bench.run_evaluation(_perfect_agent)
+        artifact = bench.build_run_artifact(results)
+
+        assert artifact.run_id
+        assert artifact.summary["task_count"] == 3
+        assert artifact.leaderboard_entry["accuracy"] == pytest.approx(1.0)
+
+    def test_export_run_artifact(self, bench: AgentBench, tmp_path: Path) -> None:
+        results = bench.run_evaluation(_perfect_agent)
+        artifact = bench.export_run_artifact(results, str(tmp_path))
+
+        bundle_path = tmp_path / f"{artifact.run_id}.json"
+        leaderboard_path = tmp_path / "leaderboard.jsonl"
+
+        assert bundle_path.exists()
+        assert leaderboard_path.exists()
+
+        bundle = json.loads(bundle_path.read_text())
+        leaderboard_lines = leaderboard_path.read_text().strip().splitlines()
+        assert bundle["summary"]["task_count"] == 3
+        assert len(leaderboard_lines) == 1


### PR DESCRIPTION
Summary:
- add async evaluation support for agent callables without breaking sync usage
- add async agent comparison support
- define a structured run artifact bundle with a stable run id and leaderboard entry
- export benchmark bundles and leaderboard summaries to disk
- document async usage and artifact export in the README

Closes #2
Closes #3

Testing:
- python3 -m py_compile src/agentbench/core.py src/agentbench/__init__.py tests/test_core.py
- PYTHONPATH=/tmp/AgentBench-fix/src python3 -m pytest /tmp/AgentBench-fix/tests